### PR TITLE
[*] Fixes update group member server-side form post error handling

### DIFF
--- a/futurenhs.app/components/_pageTemplates/GroupMemberUpdateTemplate/index.tsx
+++ b/futurenhs.app/components/_pageTemplates/GroupMemberUpdateTemplate/index.tsx
@@ -50,7 +50,7 @@ export const GroupMemberUpdateTemplate: (props: Props) => JSX.Element = ({
         formTypes.DELETE_GROUP_MEMBER
     )
 
-    const [errors, setErrors] = useState(updateFormConfig.errors)
+    const [errors, setErrors] = useState(updateFormConfig.errors || deleteFormConfig.errors)
 
     const {
         secondaryHeading,


### PR DESCRIPTION
Fixes issue raised by Shireesha here 
https://nhsidev.visualstudio.com/FutureNHS%20Open/_workitems/edit/93481?src=WorkItemMention&src-action=artifact_link

Non-js error handling was not working when user tried to update own role or remove self from group