### PR TITLE
As 99016 group invite

### DIFF
--- a/futurenhs.app/UI/scss/_imports.scss
+++ b/futurenhs.app/UI/scss/_imports.scss
@@ -13,6 +13,8 @@
 @import 'node_modules/nhsuk-frontend/packages/components/card/card';
 @import 'node_modules/nhsuk-frontend/packages/components/warning-callout/warning-callout';
 @import 'node_modules/nhsuk-frontend/packages/components/inset-text/inset-text';
+@import 'node_modules/govuk-frontend/govuk/base';
+@import 'node_modules/govuk-frontend/govuk/components/notification-banner/index';
 
 @import 'variables/variables';
 @import 'mixins/mixins';

--- a/futurenhs.app/components/GroupPageHeader/index.tsx
+++ b/futurenhs.app/components/GroupPageHeader/index.tsx
@@ -59,7 +59,9 @@ export const GroupPageHeader: (props: Props) => JSX.Element = ({
     /**
      * TODO: GROUPS_MEMBERS_INVITE action pending API, change to true to temporarily render
      */
-    const shouldRenderGroupInviteLink: boolean = true //actions?.includes(actionsConstants.GROUPS_MEMBERS_INVITE)
+    const shouldRenderGroupInviteLink: boolean = actions?.includes(
+        actionsConstants.GROUPS_MEMBERS_INVITE
+    )
     const shouldRenderPendingMessage: boolean =
         memberStatus === groupMemberStatus.PENDING
 

--- a/futurenhs.app/components/NotificationBanner/index.tsx
+++ b/futurenhs.app/components/NotificationBanner/index.tsx
@@ -1,0 +1,62 @@
+import { useRef, useState, useEffect } from 'react'
+import classNames from 'classnames'
+
+import { Props } from './interfaces'
+import { RichText } from '@components/RichText'
+import { notifications } from '@constants/notifications'
+
+export const NotificationBanner: (props: Props) => JSX.Element = ({
+    id,
+    text,
+    className,
+}) => {
+
+    const wrapperRef: any = useRef(null)
+
+    const { heading, main } = text ?? {}
+    const notificationHeading: string = heading ? heading : notifications.SUCCESS
+
+    const isAlert: boolean = notificationHeading === notifications.SUCCESS
+
+    const generatedClasses: any = {
+        wrapper: classNames('govuk-notification-banner', {['govuk-notification-banner--success']: isAlert}, 'u-mt-6', className),
+        header: classNames('govuk-notification-banner__header'),
+        title: classNames('govuk-notification-banner__title'),
+        body: classNames('govuk-notification-banner__content'),
+        bodyHeading: classNames('govuk-notification-banner__heading')
+    }
+
+    const generatedIds: any = {
+        title: `${id}-notification-banner-title`
+    }
+
+    useEffect(() => {
+
+        const wrapper: HTMLElement = wrapperRef?.current
+        wrapper?.setAttribute('tabIndex', '-1')
+        wrapper?.classList?.add('focus:u-outline-none')
+        wrapper?.focus()
+        wrapper?.addEventListener('blur', () => {
+            wrapper?.removeAttribute('tabIndex')
+        })
+
+    }, [wrapperRef.current])
+
+    return (
+        <div
+            className={generatedClasses.wrapper}
+            role={isAlert ? 'alert' : 'region'}
+            aria-labelledby={generatedIds.title}
+            ref={wrapperRef}
+        >
+            <div className={generatedClasses.header}>
+                <h2 className={generatedClasses.title} id={generatedIds.title}>{notificationHeading}</h2>
+            </div>
+            <div className={generatedClasses.body}>
+                <div className={generatedClasses.bodyHeading}>
+                    <RichText bodyHtml={main} />
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/futurenhs.app/components/NotificationBanner/interfaces.ts
+++ b/futurenhs.app/components/NotificationBanner/interfaces.ts
@@ -1,0 +1,12 @@
+import { notifications } from '@constants/notifications'
+
+export interface Notification {
+    heading?: string
+    main?: string
+}
+
+export interface Props {
+    id: number
+    text: Notification
+    className?: string
+}

--- a/futurenhs.app/components/_pageLayouts/StandardLayout/index.tsx
+++ b/futurenhs.app/components/_pageLayouts/StandardLayout/index.tsx
@@ -22,6 +22,11 @@ import { useMediaQuery } from '@hooks/useMediaQuery'
 import { useLoading } from '@hooks/useLoading'
 
 import { Props } from './interfaces'
+import { NotificationBanner } from '@components/NotificationBanner'
+import { notifications } from '@constants/notifications'
+import { Notification } from '@components/NotificationBanner/interfaces'
+import { useContext, useEffect, useState } from 'react'
+import { NotificationsContext } from '@contexts/index'
 
 export const StandardLayout: (props: Props) => JSX.Element = ({
     shouldRenderSearch = true,
@@ -39,6 +44,11 @@ export const StandardLayout: (props: Props) => JSX.Element = ({
     const router = useRouter()
     const isMobile: boolean = useMediaQuery(mediaQueries.MOBILE)
     const isLoading: boolean = useLoading().isLoading
+
+    const notificationsContext: any = useContext(NotificationsContext)
+    const shouldRenderNotification: boolean = notificationsContext?.notifications?.length > 0
+    const mostRecentNotification: Notification = notificationsContext?.notifications?.[notificationsContext.notifications.length - 1]
+    const notificationId: number = notificationsContext?.notifications?.indexOf(mostRecentNotification)
 
     const currentPathName: string = router?.pathname
     const assetPath: string = process.env.NEXT_PUBLIC_ASSET_PREFIX || ''
@@ -194,12 +204,23 @@ export const StandardLayout: (props: Props) => JSX.Element = ({
                                     <LayoutColumn hasGutters={false} mobile={0}>
                                         <MainNav
                                             navMenuList={mainNavMenuList}
-                                        />
+                                            />
                                     </LayoutColumn>
                                     <LayoutColumn
                                         id="main"
                                         className={generatedClasses.content}
-                                    >
+                                        >
+                                        {shouldRenderNotification &&
+                                                <LayoutColumnContainer>
+                                                    <LayoutColumn hasGutters={false}>
+                                                        <NotificationBanner
+                                                            id={notificationId}
+                                                            text={mostRecentNotification}
+                                                        />
+                                                    </LayoutColumn>
+                                                </LayoutColumnContainer>
+                                        }
+
                                         {children}
                                     </LayoutColumn>
                                 </>

--- a/futurenhs.app/components/_pageTemplates/GroupMemberInviteTemplate/index.tsx
+++ b/futurenhs.app/components/_pageTemplates/GroupMemberInviteTemplate/index.tsx
@@ -3,11 +3,15 @@ import { FormWithErrorSummary } from '@components/FormWithErrorSummary'
 import { LayoutColumn } from '@components/LayoutColumn'
 import { LayoutColumnContainer } from '@components/LayoutColumnContainer'
 import { formTypes } from '@constants/forms'
+import { notifications } from '@constants/notifications'
+import { Notification } from '@components/NotificationBanner/interfaces'
+import { NotificationsContext } from '@contexts/index'
 import { getGenericFormError } from '@helpers/util/form'
 import { useFormConfig } from '@hooks/useForm'
+import { useNotification } from '@hooks/useNotification'
 import { getServiceErrorDataValidationErrors } from '@services/index'
 import { postGroupMemberInvite } from '@services/postGroupMemberInvite'
-import { useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { Props } from './interfaces'
 
 /**
@@ -25,6 +29,11 @@ export const GroupMemberInviteTemplate: (props: Props) => JSX.Element = ({
         forms[formTypes.INVITE_USER]
     )
     const [errors, setErrors] = useState(formConfig?.errors)
+    const notificationsContext: any = useContext(NotificationsContext)
+
+    // useNotification('Test notification', notifications.SUCCESS)
+    
+   
 
     const { secondaryHeading } = contentText
 
@@ -32,23 +41,28 @@ export const GroupMemberInviteTemplate: (props: Props) => JSX.Element = ({
      * Client-side submission handler - TODO: Pending API
      */
     const handleSubmit = async (formData: FormData): Promise<FormErrors> => {
-        try {
-            await postGroupMemberInvite({
-                user,
-                body: formData as any,
-                groupId,
-            })
+        // try {
+        //     await postGroupMemberInvite({
+        //         user,
+        //         body: formData as any,
+        //         groupId,
+        //     })
 
-            return Promise.resolve({})
-        } catch (error) {
-            const errors: FormErrors =
-                getServiceErrorDataValidationErrors(error) ||
-                getGenericFormError(error)
+        //     return Promise.resolve({})
+        // } catch (error) {
+        //     const errors: FormErrors =
+        //         getServiceErrorDataValidationErrors(error) ||
+        //         getGenericFormError(error)
 
-            setErrors(errors)
+        //     setErrors(errors)
 
-            return Promise.resolve(errors)
-        }
+        //     return Promise.resolve(errors)
+        // }
+
+        const emailAddress: FormDataEntryValue = formData.get('Email')
+        useNotification(notificationsContext, `Invite sent to ${emailAddress}`, notifications.SUCCESS)
+        
+        return Promise.resolve(errors)
     }
 
     /**

--- a/futurenhs.app/constants/notifications.ts
+++ b/futurenhs.app/constants/notifications.ts
@@ -1,0 +1,4 @@
+export const enum notifications {
+    IMPORTANT = 'Important',
+    SUCCESS = 'Success',
+}

--- a/futurenhs.app/constants/services.ts
+++ b/futurenhs.app/constants/services.ts
@@ -39,6 +39,7 @@ export const enum services {
     POST_GROUP_FOLDER = 'postGroupFolder',
     POST_GROUP_FILE = 'postGroupFile',
     POST_GROUP_MEMBERSHIP = 'postGroupMembership',
+    POST_GROUP_MEMBER_INVITE = 'postGroupMemberInvite',
     POST_CMS_PAGE_CONTENT = 'postCmsPageContent',
     PUT_CMS_PAGE_CONTENT = 'putCmsPageContent',
     PUT_GROUP = 'putGroup',

--- a/futurenhs.app/contexts/index.tsx
+++ b/futurenhs.app/contexts/index.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React from 'react'
 
-export const ThemesContext = React.createContext({});
-export const FormsContext = React.createContext({});
-export const LoadingContext = React.createContext({});
+export const ThemesContext = React.createContext({})
+export const FormsContext = React.createContext({})
+export const LoadingContext = React.createContext({})
+export const NotificationsContext = React.createContext({})

--- a/futurenhs.app/hooks/useNotification/index.ts
+++ b/futurenhs.app/hooks/useNotification/index.ts
@@ -1,0 +1,14 @@
+
+import { notifications } from '@constants/notifications'
+import { Notification } from '@components/NotificationBanner/interfaces'
+
+export const useNotification = (notificationsContext: any, notificationBody: string, heading?: string): void => {
+
+    const newNotification: Notification = {
+        heading: heading ? heading : notifications.IMPORTANT,
+        main: notificationBody
+    }
+
+    notificationsContext.setNotifications((currentNotifications) => [...currentNotifications, newNotification])
+
+}

--- a/futurenhs.app/package-lock.json
+++ b/futurenhs.app/package-lock.json
@@ -29,6 +29,7 @@
                 "form-data": "^4.0.0",
                 "form-data-encoder": "^1.7.1",
                 "formdata-node": "^4.3.2",
+                "govuk-frontend": "^4.2.0",
                 "html-tags": "^3.2.0",
                 "is-html": "^3.0.0",
                 "js-cookie": "^3.0.1",
@@ -22715,6 +22716,14 @@
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
+            }
+        },
+        "node_modules/govuk-frontend": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
+            "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ==",
+            "engines": {
+                "node": ">= 4.2.0"
             }
         },
         "node_modules/graceful-fs": {
@@ -58982,6 +58991,11 @@
                     }
                 }
             }
+        },
+        "govuk-frontend": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
+            "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ=="
         },
         "graceful-fs": {
             "version": "4.2.8",

--- a/futurenhs.app/package.json
+++ b/futurenhs.app/package.json
@@ -36,6 +36,7 @@
         "form-data": "^4.0.0",
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.2",
+        "govuk-frontend": "^4.2.0",
         "html-tags": "^3.2.0",
         "is-html": "^3.0.0",
         "js-cookie": "^3.0.1",

--- a/futurenhs.app/pages/_app.page.tsx
+++ b/futurenhs.app/pages/_app.page.tsx
@@ -9,16 +9,20 @@ import ErrorPage from '@pages/500.page'
 import { StandardLayout } from '@components/_pageLayouts/StandardLayout'
 import { GroupLayout } from '@components/_pageLayouts/GroupLayout'
 import { AdminLayout } from '@components/_pageLayouts/AdminLayout'
-import { Loader } from '@components/Loader';
 import { layoutIds } from '@constants/routes'
 import formConfigs from '@formConfigs/index'
 import { themes } from '@constants/themes'
-import { ThemesContext, FormsContext, LoadingContext } from '@contexts/index'
+import {
+    ThemesContext,
+    FormsContext,
+    LoadingContext,
+    NotificationsContext,
+} from '@contexts/index'
 
 const CustomApp = ({ Component, pageProps }) => {
-
-    const activeRequests: any = useRef([]);
-    const [isLoading, setIsLoading] = useState(false);
+    const activeRequests: any = useRef([])
+    const [isLoading, setIsLoading] = useState(false)
+    const [notifications, setNotifications] = useState(pageProps.notifications ?? [])
 
     const router = useRouter()
     const { errors, layoutId, csrfToken } = pageProps
@@ -35,8 +39,8 @@ const CustomApp = ({ Component, pageProps }) => {
     const loadingContextConfig: Record<string, any> = {
         isLoading,
         text: {
-            loadingMessage: ''
-        }
+            loadingMessage: '',
+        },
     }
 
     const hasServerError: boolean =
@@ -44,14 +48,20 @@ const CustomApp = ({ Component, pageProps }) => {
             Object.keys(error).filter((key) => Number(key) >= 500)
         ).length > 0
     let hasFormErrors: boolean = false
-    let headTitle: string = pageProps.pageTitle || pageProps.contentText?.title;
+    let headTitle: string = pageProps.pageTitle || pageProps.contentText?.title
 
     useEffect(() => {
+        /**
+         * Empties notifications list on route change
+         */
+        router.events.on('routeChangeComplete', () => {
+            setNotifications([])
+        })
 
         /*
- * This is needed for the focus to be moved back to the beginning of the page after
- * client-side routing by next-router.
- */
+         * This is needed for the focus to be moved back to the beginning of the page after
+         * client-side routing by next-router.
+         */
         router.events.on('routeChangeComplete', () => {
             document.body.setAttribute('tabIndex', '-1')
             document.body.focus()
@@ -59,30 +69,28 @@ const CustomApp = ({ Component, pageProps }) => {
 
         document.body.addEventListener('blur', () => {
             document.body.removeAttribute('tabIndex')
-        });
+        })
 
         /*
-        * Listen for fetch events and render loading component on long running requests
-        */
-        (function (proxy, fetch): void {
-
+         * Listen for fetch events and render loading component on long running requests
+         */
+        ;(function (proxy, fetch): void {
             proxy.fetch = function (url: string) {
-                const out = fetch.apply(this, arguments);
+                const out = fetch.apply(this, arguments)
 
-                activeRequests.current.push(url);
-                setIsLoading(true);
+                activeRequests.current.push(url)
+                setIsLoading(true)
 
                 out.then(() => {
+                    activeRequests.current = activeRequests.current.filter(
+                        (item) => item !== url
+                    )
+                    !activeRequests.current.length && setIsLoading(false)
+                })
 
-                    activeRequests.current = activeRequests.current.filter(item => item !== url);
-                    !activeRequests.current.length && setIsLoading(false);
-
-                });
-
-                return out;
+                return out
             }
-
-        }(window, window.fetch))
+        })(window, window.fetch)
     }, [])
 
     if (pageProps.forms) {
@@ -99,65 +107,73 @@ const CustomApp = ({ Component, pageProps }) => {
 
     if (hasServerError) {
         return (
-            <ThemesContext.Provider value={themesContextConfig}>
-                <FormsContext.Provider value={formsContextConfig}>
-                    <LoadingContext.Provider value={loadingContextConfig}>
-                        <StandardLayout {...pageProps} user={null}>
-                            <ErrorPage statusCode={500} />
-                        </StandardLayout>
-                    </LoadingContext.Provider>
-                </FormsContext.Provider>
-            </ThemesContext.Provider>
+            <NotificationsContext.Provider value={{notifications, setNotifications}}>
+                <ThemesContext.Provider value={themesContextConfig}>
+                    <FormsContext.Provider value={formsContextConfig}>
+                        <LoadingContext.Provider value={loadingContextConfig}>
+                            <StandardLayout {...pageProps} user={null}>
+                                <ErrorPage statusCode={500} />
+                            </StandardLayout>
+                        </LoadingContext.Provider>
+                    </FormsContext.Provider>
+                </ThemesContext.Provider>
+            </NotificationsContext.Provider>
         )
     }
 
     if (layoutId === layoutIds.GROUP) {
         return (
-            <ThemesContext.Provider value={themesContextConfig}>
-                <FormsContext.Provider value={formsContextConfig}>
-                    <LoadingContext.Provider value={loadingContextConfig}>
-                        <GroupLayout {...pageProps}>
-                            <Head>
-                                <title>{headTitle}</title>
-                            </Head>
-                            <Component {...pageProps} key={router.asPath} />
-                        </GroupLayout>
-                    </LoadingContext.Provider>
-                </FormsContext.Provider>
-            </ThemesContext.Provider>
+            <NotificationsContext.Provider value={{notifications, setNotifications}}>
+                <ThemesContext.Provider value={themesContextConfig}>
+                    <FormsContext.Provider value={formsContextConfig}>
+                        <LoadingContext.Provider value={loadingContextConfig}>
+                            <GroupLayout {...pageProps}>
+                                <Head>
+                                    <title>{headTitle}</title>
+                                </Head>
+                                <Component {...pageProps} key={router.asPath} />
+                            </GroupLayout>
+                        </LoadingContext.Provider>
+                    </FormsContext.Provider>
+                </ThemesContext.Provider>
+            </NotificationsContext.Provider>
         )
     }
 
     if (layoutId === layoutIds.ADMIN) {
         return (
-            <ThemesContext.Provider value={themesContextConfig}>
-                <FormsContext.Provider value={formsContextConfig}>
-                    <LoadingContext.Provider value={loadingContextConfig}>
-                    <AdminLayout {...pageProps}>
-                        <Head>
-                            <title>{headTitle}</title>
-                        </Head>
-                        <Component {...pageProps} key={router.asPath} />
-                    </AdminLayout>
-                    </LoadingContext.Provider>
-                </FormsContext.Provider>
-            </ThemesContext.Provider>
+            <NotificationsContext.Provider value={{notifications, setNotifications}}>
+                <ThemesContext.Provider value={themesContextConfig}>
+                    <FormsContext.Provider value={formsContextConfig}>
+                        <LoadingContext.Provider value={loadingContextConfig}>
+                            <AdminLayout {...pageProps}>
+                                <Head>
+                                    <title>{headTitle}</title>
+                                </Head>
+                                <Component {...pageProps} key={router.asPath} />
+                            </AdminLayout>
+                        </LoadingContext.Provider>
+                    </FormsContext.Provider>
+                </ThemesContext.Provider>
+            </NotificationsContext.Provider>
         )
     }
 
     return (
-        <ThemesContext.Provider value={themesContextConfig}>
-            <FormsContext.Provider value={formsContextConfig}>
-                <LoadingContext.Provider value={loadingContextConfig}>
-                <StandardLayout {...pageProps}>
-                    <Head>
-                        <title>{headTitle}</title>
-                    </Head>
-                    <Component {...pageProps} key={router.asPath} />
-                </StandardLayout>
-                </LoadingContext.Provider>
-            </FormsContext.Provider>
-        </ThemesContext.Provider>
+        <NotificationsContext.Provider value={{notifications, setNotifications}}>
+            <ThemesContext.Provider value={themesContextConfig}>
+                <FormsContext.Provider value={formsContextConfig}>
+                    <LoadingContext.Provider value={loadingContextConfig}>
+                        <StandardLayout {...pageProps}>
+                            <Head>
+                                <title>{headTitle}</title>
+                            </Head>
+                            <Component {...pageProps} key={router.asPath} />
+                        </StandardLayout>
+                    </LoadingContext.Provider>
+                </FormsContext.Provider>
+            </ThemesContext.Provider>
+        </NotificationsContext.Provider>
     )
 }
 

--- a/futurenhs.app/pages/groups/[groupId]/invite/index.page.tsx
+++ b/futurenhs.app/pages/groups/[groupId]/invite/index.page.tsx
@@ -30,6 +30,7 @@ import { postGroupMemberInvite } from '@services/postGroupMemberInvite'
 import { FormErrors } from '@appTypes/form'
 import { getServiceErrorDataValidationErrors } from '@services/index'
 import { handleSSRErrorProps } from '@helpers/util/ssr/handleSSRErrorProps'
+import { notifications } from '@constants/notifications'
 
 const routeId: string = 'f872b71a-0449-4821-a8da-b75bbd451b2d'
 const props: Partial<Props> = {}
@@ -102,6 +103,12 @@ export const getServerSideProps: GetServerSideProps = withUser({
                                     body: formData,
                                     groupId,
                                 })
+
+                                const emailAddress: string = formData.get('Email')
+                                props.notifications = [{
+                                    heading: notifications.SUCCESS,
+                                    main: `Invite sent to ${emailAddress}`
+                                }]
 
                                 return {
                                     props: props,

--- a/futurenhs.app/services/postGroupMemberInvite/index.ts
+++ b/futurenhs.app/services/postGroupMemberInvite/index.ts
@@ -1,0 +1,68 @@
+import {
+    setFetchOpts as setFetchOptionsHelper,
+    fetchJSON as fetchJSONHelper,
+} from '@helpers/fetch'
+import { services } from '@constants/services'
+import { requestMethods, defaultTimeOutMillis } from '@constants/fetch'
+import { ServiceError } from '..'
+import { ServerSideFormData } from '@helpers/util/form'
+import { ServiceResponse } from '@appTypes/service'
+import { User } from '@appTypes/user'
+
+declare type Options = {
+    user: User
+    groupId: string
+    headers?: any
+    body: FormData | ServerSideFormData
+}
+
+declare type Dependencies = {
+    setFetchOptions: any
+    fetchJSON: any
+}
+
+export const postGroupMemberInvite = async (
+    { user, headers = {}, body, groupId }: Options,
+    dependencies?: Dependencies
+): Promise<ServiceResponse<null>> => {
+    const setFetchOptions =
+        dependencies?.setFetchOptions ?? setFetchOptionsHelper
+    const fetchJSON = dependencies?.fetchJSON ?? fetchJSONHelper
+
+    const { id } = user
+    const emailAddress: FormDataEntryValue = body.get('Email')
+    /**
+     * TODO: Actual endpoint TBD
+     */
+    const apiUrl: string = `${process.env.NEXT_PUBLIC_API_GATEWAY_BASE_URL}/v1/users/${id}/groups/${groupId}/invite`
+    const apiResponse: any = await fetchJSON(
+        apiUrl,
+        setFetchOptions({
+            method: requestMethods.POST,
+            headers: headers,
+            body: {
+                emailAddress: emailAddress,
+            },
+        }),
+        defaultTimeOutMillis
+    )
+
+    const apiMeta: any = apiResponse.meta
+    const apiData: any = apiResponse.json
+
+    const { ok, status, statusText } = apiMeta
+
+    if (!ok) {
+        throw new ServiceError(
+            'An unexpected error occurred when attempting to invite a group member',
+            {
+                serviceId: services.POST_SITE_USER_INVITE,
+                status: status,
+                statusText: statusText,
+                body: apiData,
+            }
+        )
+    }
+
+    return null
+}

--- a/futurenhs.app/services/postGroupMemberInvite/index.ts
+++ b/futurenhs.app/services/postGroupMemberInvite/index.ts
@@ -56,7 +56,7 @@ export const postGroupMemberInvite = async (
         throw new ServiceError(
             'An unexpected error occurred when attempting to invite a group member',
             {
-                serviceId: services.POST_SITE_USER_INVITE,
+                serviceId: services.POST_GROUP_MEMBER_INVITE,
                 status: status,
                 statusText: statusText,
                 body: apiData,

--- a/futurenhs.app/types/page.d.ts
+++ b/futurenhs.app/types/page.d.ts
@@ -7,6 +7,7 @@ import { FormConfig } from '@appTypes/form';
 import { Routes } from '@appTypes/routing';
 import { Service } from '@appTypes/service';
 import { ContentBlock } from '@components/ContentBlock';
+import { Notification } from '@components/NotificationBanner/interfaces';
 import { GenericPageTextContent, GroupsPageTextContent } from '@appTypes/content';
 import { User } from '@appTypes/user';
 
@@ -30,6 +31,7 @@ export interface Page {
     user?: User;
     className?: string;
     pageTitle?: string;
+    notifications?: Array<Notification>
 }
 
 export interface GroupPage extends Page {


### PR DESCRIPTION
Includes a commit from sprint for the invite group member page to avoid rebasing with SPRINT, can be ignored (already approved in SPRINT).

Can be tested visually on any group invite route e.g groups/aa/invite

- Adds notification banner component, renders a single notification and sets focus. Styling (using GOV.UK Frontend classes) and aria-role of banner determined by the passed heading. 'Success' notification by default.
- Adds notification context to control list of notifications, the list is cleared on route change. Currently renders last item in the list.
- Adds useNotification hook to add a notification to the list (e.g on form submit success), needs to be passed the context which will need to be declared in the template.
- Adds a 'notifications' page prop to handle server side submissions, default state of the NotificationsContext will use this prop if present
