### PR TITLE
PR: Group name is called both 'group name' and 'group title' in edit group information page #339

### DIFF
--- a/futurenhs.app/content-configs/578dfcc6-857f-4eda-8779-1d9b110888c7.ts
+++ b/futurenhs.app/content-configs/578dfcc6-857f-4eda-8779-1d9b110888c7.ts
@@ -3,6 +3,6 @@ import { GenericPageTextContent } from '@appTypes/content'
 export default {
     mainHeading: 'Edit group information',
     secondaryHeading:
-        'Edit your group title, description, introduction, logo and choose a colour pallette for your group.',
+        'Edit your group name, description, introduction, logo and choose a colour pallette for your group.',
     subTitle: 'Edit group',
 } as GenericPageTextContent


### PR DESCRIPTION
Change group title to group name