### PR TITLE
Add comment button at top of page to let you scroll into form comment box

### DIFF
--- a/futurenhs.app/pages/groups/[groupId]/forum/[discussionId]/index.page.tsx
+++ b/futurenhs.app/pages/groups/[groupId]/forum/[discussionId]/index.page.tsx
@@ -102,6 +102,7 @@ export const GroupDiscussionPage: (props: Props) => JSX.Element = ({
 }) => {
     const router = useRouter()
     const errorSummaryRef: any = useRef()
+    const commentButtonRef: any = useRef(null)
 
     const commentFormConfig: FormConfig = useFormConfig(
         formTypes.CREATE_DISCUSSION_COMMENT,
@@ -193,6 +194,13 @@ export const GroupDiscussionPage: (props: Props) => JSX.Element = ({
         setErrors(errors)
         errorSummaryRef?.current?.focus?.()
     }
+
+    /**
+     * Handle client-side add comment click
+     */
+    const handleAddCommentClick = () => {
+        commentButtonRef.current.scrollIntoView({ behavior: 'smooth' })
+    };
 
     /**
      * Handle client-side comment submission
@@ -497,6 +505,17 @@ export const GroupDiscussionPage: (props: Props) => JSX.Element = ({
                         {`Comments: ${responseCount}`}
                     </p>
                 )}
+
+                {responseCount > 2 && (
+                    <div>
+                        <button
+                            onClick={handleAddCommentClick}
+                            className="c-form_submit-button c-button u-w-full tablet:u-w-auto u-mb-6">
+                            Reply to this topic
+                        </button>
+                    </div>
+
+                )}
                 <ErrorBoundary boundaryId="group-discussion-comments">
                     {hasDiscussionComments && (
                         <DynamicListContainer
@@ -656,16 +675,18 @@ export const GroupDiscussionPage: (props: Props) => JSX.Element = ({
                                 <a>{userName}</a>
                             </Link>
                         </p>
+                        <div ref={commentButtonRef}>
                         <Form
                             csrfToken={csrfToken}
                             formConfig={commentFormConfig}
                             text={{
-                                submitButton: 'Add Comment',
+                                submitButton: 'Submit reply',
                             }}
                             shouldClearOnSubmitSuccess={true}
                             validationFailAction={handleValidationFailure}
                             submitAction={handleCommentSubmit}
                         />
+                        </div>
                     </>
                 )}
             </LayoutColumn>


### PR DESCRIPTION
Created new branch from recent main branch

- added scroll into comment box 
- Decided not to add focus on the comment textbox area because the current text box library is not NextJS compatible and raise accessibility issues. The code we implemented does focus on the box for us, but if the page renders slowly, it will take you to the bottom but won't always auto focus.

![new-gif](https://user-images.githubusercontent.com/17250560/193812696-6fc669ec-25bc-4974-b28d-4760a6870451.gif)

